### PR TITLE
fix: display product images on the homepage

### DIFF
--- a/src/resources/views/components/product-card.blade.php
+++ b/src/resources/views/components/product-card.blade.php
@@ -1,26 +1,35 @@
-<a href="/products/1" class="product-card-link">
+@php
+    $firstImage = $product->productImages->sortBy('order')->first();
+    $imageUrl = $firstImage ? $firstImage->image_url : null;
+    $isExternal = $imageUrl && str_starts_with($imageUrl, 'http');
+    $src = $imageUrl
+        ? ($isExternal ? $imageUrl : asset($imageUrl))
+        : asset('images/placeholder.png');
+@endphp
+
+<a href="{{ route('products.detail-product', $product->id) }}" class="product-card-link">
 
 <div class="product-card">
 
     <div class="card-img-wrap">
-        <img src="{{ $image }}" alt="{{ $name }}" class="card-img">
+                <img src="{{ $src }}" alt="{{ $product->name }}" class="card-img">
     </div>
 
     <div class="card-body-custom">
 
-        <h3 class="product-name">{{ $name }}</h3>
+        <h3 class="product-name">{{ $product->name }}</h3>
 
-        <p class="product-price">{{ $price }}</p>
+        <p class="product-price">Rp {{ number_format($product->price, 0, ',', '.') }}</p>
 
         <span class="condition-badge">
-            {{ $condition }}
+            {{ $product->status }}
         </span>
 
-    <button class="wishlist-btn" 
-        data-name="{{ $product['name'] }}" 
-        data-price="{{ $product['price'] }}" 
-        data-condition="{{ $product['condition'] }}" 
-        data-image="{{ $product['image'] }}">
+    <button class="wishlist-btn"
+        data-name="{{ $product->name }}"
+        data-price="{{ $product->price }}"
+        data-condition="{{ $product->status }}"
+        data-image="{{ $src }}">
         <i class="bi bi-heart"></i>
     </button>
 

--- a/src/resources/views/home/home.blade.php
+++ b/src/resources/views/home/home.blade.php
@@ -14,71 +14,6 @@
 
 @section('content')
 
-@php
-$products = [
-    [
-        'name' => 'iPad Air 4 64GB',
-        'price' => 'Rp 4.200.000',
-        'condition' => 'Bekas Seperti Baru',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Buku Kalkulus',
-        'price' => 'Rp 45.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Jaket Hoodie Uniqlo',
-        'price' => 'Rp 120.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Headset Sony WH-CH510',
-        'price' => 'Rp 250.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Meja Belajar Lipat',
-        'price' => 'Rp 150.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'MacBook Air M1 8GB',
-        'price' => 'Rp 9.500.000',
-        'condition' => 'Bekas Seperti Baru',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Nike Air Max 270',
-        'price' => 'Rp 380.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Raket Badminton Yonex',
-        'price' => 'Rp 85.000',
-        'condition' => 'Bekas Layak Pakai',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Kemeja Flanel Oversize',
-        'price' => 'Rp 55.000',
-        'condition' => 'Bekas Seperti Baru',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-    [
-        'name' => 'Sepatu Running Adidas',
-        'price' => 'Rp 290.000',
-        'condition' => 'Bekas Baik',
-        'image' => asset('images/Elemen-1.png'),
-    ],
-];
-@endphp
-
 {{-- HERO --}}
 <section class="hero-banner" style="background-image: url('{{ asset('images/Elemen-2.png') }}');">
     <div class="hero-content">
@@ -102,9 +37,13 @@ $products = [
 {{-- PRODUCT GRID --}}
 <section class="product-grid">
 
-    @foreach ($products as $product)
-        @include('components.product-card', $product)
-    @endforeach
+    @forelse ($products as $product)
+       @include('components.product-card', ['product' => $product])
+    @empty
+        <div class="no-product">
+            <p>Belum ada produk yang dijual saat ini.</p>
+        </div>
+    @endforelse
 
 </section>
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -30,7 +30,7 @@ Route::middleware('auth')->group(function () {
     // ADMIN
     // ==========================================
     Route::middleware(RoleMiddleware::class . ':admin')->group(function () {
-        
+
         // Dashboard
         Route::get('/admin/dashboard-admin', function () {
             return view('admin.dashboard-admin');
@@ -66,11 +66,16 @@ Route::middleware('auth')->group(function () {
     // ==========================================
     // USER (Buyer & Seller)
     // ==========================================
-    
+
     // Home & Pencarian
-    Route::get('/home', function () {
-        return view('home.home');
-    })->name('home');
+    // routes/web.php
+Route::get('/home', function () {
+    $products = \App\Models\Product::with('productImages')
+                    ->where('status', 'dijual')
+                    ->latest()
+                    ->get();
+    return view('home.home', compact('products'));
+})->name('home')->middleware(['web', 'auth']);
 
     Route::get('/search', [ProductController::class, 'search'])->name('products.search');
     Route::get('/products/{id}', [ProductController::class, 'show'])->name('products.detail-product');
@@ -93,7 +98,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/checkout/{token}', [CheckoutController::class, 'store'])->name('checkout.store');
     Route::get('/checkout/{transaction}/upload-proof', [CheckoutController::class, 'showUploadProof'])->name('checkout.uploadProofForm');
     Route::post('/checkout/{transaction}/upload-proof', [CheckoutController::class, 'uploadProof'])->name('checkout.uploadProof');
-    
+
     // Notifikasi & Profil
     Route::view('/notification', 'notification.notification')->name('notification');
     Route::view('/profile', 'profile.profile-user')->name('profile.profile-user');


### PR DESCRIPTION
## Summary
Fix halaman homepage yang gagal menampilkan produk dari database.

## Changes
- Fix `$products` tidak dikirim dari route ke view `home.blade.php`
- Tambah eager loading relasi `productImages` pada query produk di route `/home`
- Refactor `product-card.blade.php` untuk menggunakan data dari object `$product` 
  menggantikan variabel terpisah (`$name`, `$price`, `$image`, dll)
- Handle dua jenis sumber gambar: URL eksternal (Unsplash) dan path lokal (`public/images/`)
- Tambah fallback ke `placeholder.png` jika produk tidak memiliki gambar
- Filter produk hanya menampilkan status `dijual`

## Root Cause
`product-card.blade.php` menggunakan variabel standalone (`$name`, `$price`, `$image`) 
yang tidak pernah dikirim, sedangkan data produk tersedia melalui object `$product` 
dan relasinya `$product->productImages`.

## Testing
- Homepage berhasil menampilkan produk dari seeder
- Gambar dari URL eksternal dan path lokal keduanya tampil dengan benar