### PR TITLE
fix: block duplicate active purchase links and fix premature link expiry

### DIFF
--- a/src/app/Http/Controllers/ChatController.php
+++ b/src/app/Http/Controllers/ChatController.php
@@ -154,6 +154,18 @@ class ChatController extends Controller
             abort(403, 'Hanya seller yang dapat mengirim link pembelian.');
         }
 
+        // Cek apakah masih ada link aktif yang belum kedaluwarsa untuk chat ini
+        $activeLink = PurchaseLink::where('chat_id', $chat->id)
+            ->where('is_used', false)
+            ->where('expired_at', '>', now())
+            ->first();
+
+        if ($activeLink) {
+            return back()->withErrors([
+                'active_link' => 'Masih ada link pembelian aktif yang belum kedaluwarsa. Tunggu hingga link tersebut digunakan oleh buyer atau habis masa berlakunya.',
+            ]);
+        }
+
         // Bersihkan titik ribuan Rupiah dari input
         if ($request->has('deal_price')) {
             $request->merge([

--- a/src/app/Http/Controllers/CheckoutController.php
+++ b/src/app/Http/Controllers/CheckoutController.php
@@ -53,7 +53,7 @@ class CheckoutController extends Controller
 
         $chat = $purchaseLink->chat;
 
-        // Buat transaksi
+        // Buat transaksi — link belum ditandai 'used' karena buyer belum upload bukti
         $transaction = Transaction::create([
             'purchase_link_id' => $purchaseLink->id,
             'buyer_id'         => auth()->id(),
@@ -62,9 +62,6 @@ class CheckoutController extends Controller
             'status'           => 'menunggu_pembayaran',
             'payment_method'   => $validated['payment_method'],
         ]);
-
-        // Tandai link sudah dipakai
-        $purchaseLink->update(['is_used' => true]);
 
         return redirect()->route('checkout.uploadProofForm', $transaction->id)
             ->with('success', 'Checkout berhasil! Silakan upload bukti pembayaran.');
@@ -105,6 +102,9 @@ class CheckoutController extends Controller
             'payment_proof' => $path,
             'status'        => 'dibayar',
         ]);
+
+        // Tandai link sudah dipakai setelah bukti pembayaran berhasil dikirim
+        $transaction->purchaseLink->update(['is_used' => true]);
 
         return redirect()->route('home')
             ->with('success', 'Bukti pembayaran berhasil dikirim! Menunggu konfirmasi seller.');


### PR DESCRIPTION
Bug 1 (#85): Add validation in sendPurchaseLink() to prevent seller from creating a new purchase link while an active (non-expired, unused) link already exists for the same chat session.

Bug 2 (#86): Move is_used flag from store() to uploadProof() so that a purchase link only becomes invalid after the buyer successfully submits payment proof, not when they simply visit or leave the checkout page.

Closes #85
Closes #86