### PR TITLE
Bugfix/search keyword filter

### DIFF
--- a/src/app/Http/Controllers/ProductController.php
+++ b/src/app/Http/Controllers/ProductController.php
@@ -143,10 +143,7 @@ class ProductController extends Controller
         }
 
         if ($request->filled('q')) {
-            $query->where(function ($q) use ($keyword) {
-                $q->where('name', 'like', "%{$keyword}%")
-                  ->orWhere('description', 'like', "%{$keyword}%");
-            });
+            $query->where('name', 'like', "%{$keyword}%");
         }
 
         if ($request->filled('sort')) {

--- a/src/app/Http/Controllers/ProductController.php
+++ b/src/app/Http/Controllers/ProductController.php
@@ -140,15 +140,13 @@ class ProductController extends Controller
             if (isset($catMap[$request->category])) {
                 $query->where('category_id', $catMap[$request->category]);
             }
+        }
 
-            $keyword = null;
-        } else {
-            if ($request->filled('q')) {
-                $query->where(function ($q) use ($keyword) {
-                    $q->where('name', 'like', "%{$keyword}%")
-                      ->orWhere('description', 'like', "%{$keyword}%");
-                });
-            }
+        if ($request->filled('q')) {
+            $query->where(function ($q) use ($keyword) {
+                $q->where('name', 'like', "%{$keyword}%")
+                  ->orWhere('description', 'like', "%{$keyword}%");
+            });
         }
 
         if ($request->filled('sort')) {


### PR DESCRIPTION
Bug introduced in commit 5fc7426. The if-else structure caused the keyword to be set to null whenever a category filter was active, making keyword search completely ignored when a category was selected.

Also restructured the logic so keyword filter and category filter run independently of each other, allowing both to be used at the same time.

Closes #87