### PR TITLE
fix: align purchase link lifecycle and transaction status flow for semart app

### DIFF
--- a/src/app/Http/Controllers/Api/ChatController.php
+++ b/src/app/Http/Controllers/Api/ChatController.php
@@ -223,6 +223,19 @@ class ChatController extends Controller
             return response()->json(['message' => 'Hanya seller yang dapat mengirim link pembelian.'], 403);
         }
 
+        // Cek apakah masih ada link aktif yang belum kedaluwarsa untuk chat ini
+        $activeLink = PurchaseLink::where('chat_id', $chat->id)
+            ->where('is_used', false)
+            ->where('expired_at', '>', now())
+            ->latest()
+            ->first();
+
+        if ($activeLink) {
+            return back()->withErrors([
+                'active_link' => 'Masih ada link pembelian aktif yang belum kedaluwarsa. Tunggu hingga link tersebut digunakan oleh buyer atau habis masa berlakunya.',
+            ]);
+        }
+
         // Bersihkan titik ribuan dari deal_price
         if ($request->has('deal_price')) {
             $request->merge([
@@ -239,6 +252,13 @@ class ChatController extends Controller
         ]);
 
         $token = Str::uuid()->toString();
+
+        $product = $chat->product;
+        if ($product->status === 'sold_out') {
+            return response()->json([
+                'message' => 'Produk sudah terjual.'
+            ], 422);
+        }
 
         $purchaseLink = PurchaseLink::create([
             'chat_id'         => $chat->id,

--- a/src/app/Http/Controllers/Api/CheckoutController.php
+++ b/src/app/Http/Controllers/Api/CheckoutController.php
@@ -107,18 +107,20 @@ class CheckoutController extends Controller
             'payment_method' => 'required|string',
         ]);
 
-        $chat = $purchaseLink->chat;
+        $transaction = Transaction::where(
+            'purchase_link_id',
+            $purchaseLink->id
+        )->first();
 
-        $transaction = Transaction::create([
-            'purchase_link_id' => $purchaseLink->id,
-            'buyer_id'         => auth()->id(),
-            'product_id'       => $chat->product_id,
-            'total_price'      => $purchaseLink->deal_price,
-            'status'           => 'menunggu_pembayaran',
-            'payment_method'   => $validated['payment_method'],
+        if (!$transaction) {
+            return response()->json([
+                'message' => 'Transaksi tidak ditemukan.'
+            ], 404);
+        }
+
+        $transaction->update([
+            'payment_method' => $validated['payment_method'],
         ]);
-
-        $purchaseLink->update(['is_used' => true]);
 
         return response()->json([
             'message'        => 'Checkout berhasil! Silakan upload bukti pembayaran.',
@@ -149,6 +151,9 @@ class CheckoutController extends Controller
             'payment_proof' => $path,
             'status'        => 'dibayar',
         ]);
+
+        // Tandai link sudah dipakai setelah bukti pembayaran berhasil dikirim
+        $transaction->purchaseLink->update(['is_used' => true]);
 
         return response()->json([
             'message'           => 'Bukti pembayaran berhasil dikirim! Menunggu konfirmasi seller.',

--- a/src/app/Http/Controllers/Api/HistoryController.php
+++ b/src/app/Http/Controllers/Api/HistoryController.php
@@ -22,7 +22,7 @@ class HistoryController extends Controller
 
         $statusClassMap = [
             'menunggu_pembayaran' => 'status-menunggu',
-            'dibayar'             => 'status-menunggu',
+            'dibayar'             => 'status-dibayar',
             'selesai'             => 'status-selesai',
             'gagal'               => 'status-gagal',
         ];
@@ -125,6 +125,12 @@ class HistoryController extends Controller
             return response()->json([
                 'message' => 'Anda tidak memiliki akses untuk menutup transaksi ini.',
             ], 403);
+        }
+
+        if ($transaction->status !== 'dibayar') {
+            return response()->json([
+                'message' => 'Transaksi belum dapat diselesaikan.'
+            ], 400);
         }
 
         $transaction->update([

--- a/src/resources/css/base/variables.css
+++ b/src/resources/css/base/variables.css
@@ -16,12 +16,15 @@
     --gray-text: #6B7280;
     --border-gray: #E5E7EB;
 
-    --status-menunggu-bg:   rgba(245, 158, 11, 0.12);
-    --status-menunggu-text: #D97706;
-    --status-menunggu-border: rgba(245, 158, 11, 0.28);
+    --status-menunggu-bg:   rgba(229, 231, 235, 0.8);
+    --status-menunggu-text: #475569;
+    --status-menunggu-border: rgba(148, 163, 184, 0.6);
     --status-dijual-bg:     rgba(16, 185, 129, 0.11);
     --status-dijual-text:   #059669;
     --status-dijual-border: rgba(16, 185, 129, 0.26);
+    --status-dibayar-bg:   rgba(245, 158, 11, 0.12);
+    --status-dibayar-text: #D97706;
+    --status-dibayar-border: rgba(245, 158, 11, 0.28);
     --status-soldout-bg:    rgba(107, 114, 128, 0.11);
     --status-soldout-text:  #6B7280;
     --status-soldout-border: rgba(107, 114, 128, 0.26);


### PR DESCRIPTION
Perubahan yang dilakukan (utamanya dilakukan untuk api controller pada p mobile):

* Mencegah pembuatan purchase link aktif ganda pada chat yang sama
* Menyesuaikan siklus hidup purchase link agar tidak langsung kadaluarsa saat checkout dibuka
* Memastikan purchase link baru dianggap digunakan setelah buyer mengirim bukti pembayaran
* Menyelaraskan alur transaksi antara Web dan API Mobile
* Memperbarui status transaksi menjadi: menunggu_pembayaran → dibayar → selesai
* Menambahkan validasi agar hanya transaksi berstatus dibayar yang dapat diselesaikan seller
* Mengubah status produk menjadi sold_out saat transaksi selesai
* Memblokir penggunaan purchase link untuk produk yang sudah sold_out
* Menambahkan dukungan status-dibayar pada API dan tampilan riwayat transaksi
* Memperbaiki pemetaan status transaksi pada fitur riwayat pembelian dan penjualan
