### PR TITLE
fix: resolve local product image URLs consistently across mobile API endpoints

### DIFF
--- a/src/app/Http/Controllers/Api/ChatController.php
+++ b/src/app/Http/Controllers/Api/ChatController.php
@@ -23,7 +23,11 @@ class ChatController extends Controller
         $latestMsg    = $chat->latestMessage;
 
         if ($imageUrl && !str_starts_with($imageUrl, 'http')) {
-            $imageUrl = asset('storage/' . $imageUrl);
+            if (str_starts_with($imageUrl, 'products/')) {
+                $imageUrl = asset('storage/' . $imageUrl);
+            } else {
+                $imageUrl = asset($imageUrl);
+            }
         }
 
         return [

--- a/src/app/Http/Controllers/Api/CheckoutController.php
+++ b/src/app/Http/Controllers/Api/CheckoutController.php
@@ -32,7 +32,11 @@ class CheckoutController extends Controller
 
         $imageUrl = $product->productImages->first()?->image_url ?? null;
         if ($imageUrl && !str_starts_with($imageUrl, 'http')) {
-            $imageUrl = asset('storage/' . $imageUrl);
+            if (str_starts_with($imageUrl, 'products/')) {
+                $imageUrl = asset('storage/' . $imageUrl);
+            } else {
+                $imageUrl = asset($imageUrl);
+            }
         }
 
         // Ambil filter metode pembayaran yang dipilih seller saat membuat link

--- a/src/app/Http/Controllers/Api/ProductController.php
+++ b/src/app/Http/Controllers/Api/ProductController.php
@@ -23,10 +23,19 @@ class ProductController extends Controller
         if (!$imageUrl) {
             return asset('images/placeholder.png');
         }
+
+        // Unsplash / external URL
         if (str_starts_with($imageUrl, 'http')) {
             return $imageUrl;
         }
-        return asset('storage/' . $imageUrl);
+
+        // Upload user
+        if (str_starts_with($imageUrl, 'products/')) {
+            return asset('storage/' . $imageUrl);
+        }
+
+        // Asset bawaan repo
+        return asset($imageUrl);
     }
 
     /**

--- a/src/app/Http/Controllers/Api/WishlistController.php
+++ b/src/app/Http/Controllers/Api/WishlistController.php
@@ -24,7 +24,11 @@ class WishlistController extends Controller
             $imageUrl = $product->productImages->first()?->image_url ?? null;
 
             if ($imageUrl && !str_starts_with($imageUrl, 'http')) {
-                $imageUrl = asset('storage/' . $imageUrl);
+                if (str_starts_with($imageUrl, 'products/')) {
+                    $imageUrl = asset('storage/' . $imageUrl);
+                } else {
+                    $imageUrl = asset($imageUrl);
+                }
             }
 
             return [


### PR DESCRIPTION
Perubahan yang dilakukan:

- Memperbaiki URL gambar produk lokal pada API mobile
- Menambahkan dukungan untuk gambar yang disimpan di folder images/
- Menjaga kompatibilitas untuk gambar dari Unsplash/external URL
- Menyamakan proses resolusi URL gambar di endpoint produk, chat, wishlist, checkout, dan riwayat transaksi
- Memastikan placeholder tetap digunakan jika gambar tidak tersedia
- Memperbaiki masalah gambar produk yang tidak tampil di aplikasi Android meskipun tampil normal di website