### PR TITLE
fix: override Reverb cURL host to 127.0.0.1 to avoid Windows connecti…

### DIFF
--- a/src/config/broadcasting.php
+++ b/src/config/broadcasting.php
@@ -36,7 +36,7 @@ return [
             'secret' => env('REVERB_APP_SECRET'),
             'app_id' => env('REVERB_APP_ID'),
             'options' => [
-                'host' => env('REVERB_HOST'),
+                'host' => env('REVERB_HOST') === '0.0.0.0' ? '127.0.0.1' : env('REVERB_HOST', '127.0.0.1'),
                 'port' => env('REVERB_PORT', 443),
                 'scheme' => env('REVERB_SCHEME', 'https'),
                 'useTLS' => env('REVERB_SCHEME', 'https') === 'https',


### PR DESCRIPTION
Problem / Context
Saat melakukan pengujian fitur Live Chat, developer yang menggunakan sistem operasi Windows mengalami masalah Internal Server Error 500 dengan pesan: Pusher error: cURL error 7: Failed to connect to 0.0.0.0 port 8080 after 1 ms: Couldn't connect to server

Penyebab utamanya adalah nilai REVERB_HOST yang ter-set secara otomatis ke 0.0.0.0 (saat menjalankan php artisan reverb:install). Ketika Laravel backend mencoba mengirim broadcast request lewat fungsi internal cURL ke http://0.0.0.0:8080, sistem operasi Windows menolak permintaan ini karena 0.0.0.0 bukanlah route lokal yang sah untuk HTTP Client.

Solution
Melakukan sedikit pembelokan (override) di level konfigurasi src/config/broadcasting.php.

Jika aplikasi mendeteksi konfigurasi environment REVERB_HOST menggunakan string "0.0.0.0", maka nilai tersebut akan otomatis dibelokkan menjadi "127.0.0.1" secara eksklusif untuk kebutuhan Guzzle/cURL internal Laravel.

Sedangkan Server Reverb utama (php artisan reverb:start) tetap diizinkan memakai binding 0.0.0.0 sehingga emulator Android maupun device eksternal lain tetap bisa me-listen WebSockets tanpa masalah.

Impact
Frictionless untuk tim: Semua anggota tim bisa langsung menarik (pull) branch ini dan mencoba fitur Live Chat dengan lancar tanpa perlu mengubah isi file .env di laptop mereka masing-masing.
Terhindar dari crash API akibat exception BroadcastException.
How to Test
Lakukan git pull dari branch ini.
Pastikan server web (php artisan serve) dan reverb (php artisan reverb:start) berjalan.
Jalankan aplikasi web atau mobile, cobalah untuk mengirim chat.
Pastikan pesan masuk dengan lancar dan tidak ada lagi Error 500 pada terminal / Postman.